### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,12 +1,12 @@
 
-# KEYWORD1 
-PWM_BitBanging_Port	        KEYWORD1
- 
-# KEYWORD2 
-PinValue             KEYWORD2
-PORT             KEYWORD2
-DDR             KEYWORD2
-run             KEYWORD2
-setup             KEYWORD2
+# KEYWORD1
+PWM_BitBanging_Port	KEYWORD1
 
-# KEYWORD3 
+# KEYWORD2
+PinValue	KEYWORD2
+PORT	KEYWORD2
+DDR	KEYWORD2
+run	KEYWORD2
+setup	KEYWORD2
+
+# KEYWORD3


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords